### PR TITLE
fix bpp parsing format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ===============
 RFB server library
 ===============
-
+<pre>
 mkdir build
 cd build
 cmake ..
-
+</pre>

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 RFB server library
 ===============
 
+mkdir build
+cd build
+cmake ..
+

--- a/src/fb.c
+++ b/src/fb.c
@@ -299,12 +299,14 @@ trfb_framebuffer_t* trfb_framebuffer_create_of_format(unsigned width, unsigned h
 		return NULL;
 	}
 
+	fmt->bpp /= 8;
+
 	if (fmt->bpp != 1 && fmt->bpp != 2 && fmt->bpp != 4) {
 		trfb_msg("Invalid format: BPP = %d", fmt->bpp);
 		return NULL;
 	}
 
-	fb = trfb_framebuffer_create(width, height, fmt->bpp / 8);
+	fb = trfb_framebuffer_create(width, height, fmt->bpp);
 	if (!fb) {
 		return NULL;
 	}

--- a/src/server.c
+++ b/src/server.c
@@ -219,7 +219,7 @@ static void stop_all_connections(trfb_server_t *srv)
 		}
 	}
 
-	trfb_msg("I:all clients have been stoped...");
+	trfb_msg("I:all clients have been stopped.");
 	return;
 }
 


### PR DESCRIPTION
Seems that we forgot this with recent changes for lib4l2, just divide by 8 before check:
build # ./test/trfb_test 
INFO: starting server...
INFO: server started!
INFO: new client!
...
INFO: negotiation done
INFO: [localhost:34589] FORMAT: bpp = 32, depth = 24, big_endian = 0, true_color = 1
ERROR: Invalid format: BPP = 32
ERROR: Can not create framebuffer for requested format.
EVENT: 2
